### PR TITLE
cleanup: Remove old discord link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,1 @@
 blank_issues_enabled: false
-contact_links:
-  - name: Discord Chat
-    url: https://discord.com/invite/abnxwN6r9v
-    about: Ask questions and discuss with other nijilive users in real time.


### PR DESCRIPTION
Removes the old discord linking in the github issues template