### PR TITLE
Improve gitver experience

### DIFF
--- a/.github/workflows/build-and-candidate.yml
+++ b/.github/workflows/build-and-candidate.yml
@@ -42,9 +42,6 @@ jobs:
 
     - name: 'Build nijiexpose'
       run: |
-        # Build metadata (like version information and icons)
-        dub build --config=meta
-
         # Build the project, with its main file included, without unittests
         dub build --compiler=ldc2 --build=release --config=linux-full
 
@@ -93,9 +90,6 @@ jobs:
               }
           }
           Invoke-VSDevEnvironment
-          
-          # Build metadata (like version information and icons)
-          dub build --config=meta
           
           # Build the project, with its main file included, without unittests
           dub build --compiler=ldc2 --build=release --config=win32-full
@@ -168,9 +162,6 @@ jobs:
       env:
         DFLAGS: "-force-dwarf-frame-section=false"
       run: |
-        # Build metadata (like version information and icons)
-        dub build --config=meta
-        
         # First build ARM64 version...
         echo "Building arm64 binary..."
         dub build --build=release --config=osx-full --arch=arm64-apple-macos

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -43,9 +43,6 @@ jobs:
 
     - name: 'Build nijiexpose'
       run: |
-        # Build metadata (like version information and icons)
-        dub build --config=meta
-
         # Build the project, with its main file included, without unittests
         dub build --compiler=ldc2 --build=release --config=linux-full
 
@@ -104,9 +101,6 @@ jobs:
               }
           }
           Invoke-VSDevEnvironment
-          
-          # Build metadata (like version information and icons)
-          dub build --config=meta
           
           # Build the project, with its main file included, without unittests
           dub build --compiler=ldc2 --build=release --config=win32-full
@@ -208,9 +202,6 @@ jobs:
       env:
         DFLAGS: "-force-dwarf-frame-section=false"
       run: |
-        # Build metadata (like version information and icons)
-        dub build --config=meta
-        
         # First build ARM64 version...
         echo "Building arm64 binary..."
         dub build --build=release --config=osx-full --arch=arm64-apple-macos

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -76,9 +76,6 @@ jobs:
 
     - name: 'Build nijiexpose'
       run: |
-        # Build metadata (like version information and icons)
-        dub build --config=meta
-
         # Build the project, with its main file included, without unittests
         dub build --compiler=ldc2 --config=linux-nightly --debug=InExperimental
           

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -37,9 +37,6 @@ jobs:
 
     - name: 'Build and Test'
       run: |
-        # Build metadata (like version information and icons)
-        dub build --config=meta
-
         # Build the project, with its main file included, without unittests
         dub build --compiler=ldc2 --build=release --config=linux-full
 

--- a/dub.sdl
+++ b/dub.sdl
@@ -21,6 +21,9 @@ lflags "-rpath=$$ORIGIN" platform="linux"
 versions "GL_32" "USE_SDL2" "USE_GL" "SDL_2020" "USE_OpenGL3"
 stringImportPaths "res"
 
+preBuildCommands "sh update-gitver.sh nijiexpose INS"
+preBuildCommands "rc.exe /v build-aux\\windows\\nijiexpose.rc" platform="windows"
+
 // Uncomment following lines to enable JINS MEME Logger module.
 //versions "JML"
 //subConfiguration "facetrack-d" "jml"
@@ -35,15 +38,6 @@ configuration "barebones" {
 	dependency "dportals" version="~>0.1.0"
 }
 
-
-// Official build configurations.
-// Do not package your compilation of Inochi Creator with these configurations
-// unless you have prior permission from the nijigenerate Project.
-configuration "meta" {
-	targetType "none"
-	preGenerateCommands "dub run gitver -- --prefix INS --file source/nijiexpose/ver.d --mod nijiexpose.ver --appname \"nijiexpose\" --itchfile version.txt"
-	preGenerateCommands "rc.exe /v build-aux\\windows\\nijiexpose.rc" platform="windows"
-}
 
 configuration "linux-full" {
 	platforms "linux"

--- a/update-gitver.sh
+++ b/update-gitver.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+dub run gitver -- --prefix $2 --file source/$1/ver.d.new --mod $1.ver --appname $1
+cmp source/$1/ver.d source/$1/ver.d.new &>/dev/null && rm source/$1/ver.d.new && exit 0 || true
+mv -f source/$1/ver.d.new source/$1/ver.d


### PR DESCRIPTION
Do not use a separate "meta" config for metadata, since that makes it confusing to build the project for the first time. Just run gitver directly on build.

Also wrap it in a script that only replaces the version file if it changed. This avoids forcing a full source rebuild if nothing changed.