### PR TITLE
Fix aarch64 build

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -18,6 +18,9 @@ copyFiles "res/licenses/*"
 
 dflags "-mscrtlib=msvcrt" platform="windows-ldc"
 lflags "-rpath=$$ORIGIN" platform="linux"
+// Add supported arches that aren't x86_64 here, since lumars does not ship a static lua
+lflags "-llua-5.1" platform="linux-aarch64"
+
 versions "GL_32" "USE_SDL2" "USE_GL" "SDL_2020" "USE_OpenGL3"
 stringImportPaths "res"
 


### PR DESCRIPTION
lumars does not ship a static luajit for linux-aarch64, so we need to use the system library. Other supported arches should be added this way.