### PR TITLE
Fix crash from incorrect `trackerPath` initialization, add option to open config folder

### DIFF
--- a/source/nijiexpose/tracking/tracker.d
+++ b/source/nijiexpose/tracking/tracker.d
@@ -61,7 +61,7 @@ public:
     DeviceInfo[] deviceList = null;
 
     this () {
-        this.trackerPath = buildPath(thisExePath(), "nijitrack");
+        this.trackerPath = buildPath(thisExePath().dirName, "nijitrack");
     }
 
     string scriptPath() {

--- a/source/nijiexpose/windows/main.d
+++ b/source/nijiexpose/windows/main.d
@@ -162,6 +162,13 @@ protected:
                     if (uiImMenuItem(__("Settings"))) {
                         inPushToolWindow(new SettingWindow());
                     }
+
+                    // Opens the directory where configuration resides in the user's file browser.
+                    if (uiImMenuItem(__("Open Configuration Folder"), null, false, true)) {
+                        import std.process;
+                        // FIXME: uiOpenLink not working on osxfinder, so we use browse instead
+                        browse(inGetAppConfigPath());
+                    }
                     uiImEndMenu();
                 }
 


### PR DESCRIPTION
## Summary  
This PR fixes a crash caused by incorrect `trackerPath` initialization (was using full file path instead of `dirName`).  

Additionally, an option has been added to open the configuration folder directly in the file browser.  
This makes it easier for users and developers to debug or inspect configuration files without manually locating the folder.  

## Changes  
- Fix: Correct `trackerPath` initialization using `dirName` to prevent crash.  
- Feat: Add menu/option to open config folder in file browser for easier debugging.  

## Notes  
The main purpose of this PR is the crash fix.  
The new option for opening config folder is a small quality-of-life improvement added along the way.


```
std.file.FileException@std/file.d(3041): /Users/user/nijiexpose.app/Contents/MacOS/nijiexpose/nijitrack: Not a directory
----------------
??:? @safe bool std.file.ensureDirExists!().ensureDirExists(scope const(char)[]) [0xxxxxxxxxx]
??:? @safe void std.file.mkdirRecurse(scope const(char)[]) [0xxxxxxxxxx]
??:? int nijiexpose.tracking.tracker.Tracker.install().__foreachbody_L186_C9(ref immutable(char)[], ref std.zip.ArchiveMember) [0xxxxxxxxxx]
??:? _aaApply2 [0xxxxxxxxxx]
??:? nijiexpose.utils.subprocess.SubProcess!(true, false).SubProcess nijiexpose.tracking.tracker.Tracker.install() [0xxxxxxxxxx]
??:? void nijiexpose.windows.settings.SettingWindow.onUpdate() [0xxxxxxxxxx]
??:? void nijiui.toolwindow.ToolWindow.update() [0xxxxxxxxxx]
??:? void nijiui.toolwindow.inUpdateToolWindows() [0xxxxxxxxxx]
??:? void nijiui.core.window.appwin.InApplicationWindow.update().doUpdate() [0xxxxxxxxxx]
??:? void nijiui.core.window.appwin.InApplicationWindow.update() [0xxxxxxxxxx]
??:? _Dmain [0xxxxxxxxxx]
Process $pid exited with status = 1 (0x00000001)
```