### PR TITLE
Adjusted for new-rendering pipeline, and add triple buffer fallback toggle

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -20,6 +20,8 @@ import nijiexpose.framesend;
 import nijiexpose.tracking.expr;
 import nijiexpose.tracking.tracker;
 import std.process;
+import nijilive.core.nodes.common : nlSetTripleBufferFallback, nlIsTripleBufferFallbackEnabled;
+import nijiui.core.settings : inSettingsGet;
 
 void main(string[] args) {
     insLogInfo("nijiexpose %s, args=%s", INS_VERSION, args[1..$]);
@@ -49,6 +51,9 @@ void main(string[] args) {
     insScene.init();
     insInitFrameSending();
     inPostProcessingAddBasicLighting();
+    // Apply triple buffer fallback setting from config.
+    bool tripleFallback = inSettingsGet!bool("TripleBufferFallback", nlIsTripleBufferFallbackEnabled());
+    nlSetTripleBufferFallback(tripleFallback);
 
     // Draw window
     while(window.isAlive) {

--- a/source/nijiexpose/windows/main.d
+++ b/source/nijiexpose/windows/main.d
@@ -21,6 +21,7 @@ import nijiui.toolwindow;
 import nijiui.panel;
 import nijiui.input;
 import nijilive;
+import nijilive.core.render.backends.opengl.runtime : oglDrawScene;
 import ft;
 import i18n;
 import nijiui.utils.link;
@@ -93,7 +94,7 @@ protected:
         insScene.update();
         insSendFrame();
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
-        inDrawScene(vec4(0, 0, width, height));
+        oglDrawScene(vec4(0, 0, width, height));
     }
 
     override

--- a/source/nijiexpose/windows/settings.d
+++ b/source/nijiexpose/windows/settings.d
@@ -15,6 +15,7 @@ import ft;
 import std.algorithm;
 import std.file;
 import nijiexpose.utils.subprocess;
+import nijilive.core.nodes.common : nlIsTripleBufferFallbackEnabled, nlSetTripleBufferFallback;
 
 import std.algorithm.mutation;
 
@@ -172,6 +173,16 @@ public:
                         }
                         uiImSameLine();
                         uiImLabel(_("Frame rate: %.2f fps".format(neGetFPS())));
+                    uiImUnindent();
+                }
+                if (uiImHeader(__("Triple buffer fallback"), true)) {
+                    uiImIndent();
+                        bool tripleFallback = inSettingsGet!bool("TripleBufferFallback", nlIsTripleBufferFallbackEnabled());
+                        if (uiImCheckbox(__("Enable triple buffer fallback"), tripleFallback)) {
+                            inSettingsSet("TripleBufferFallback", tripleFallback);
+                            nlSetTripleBufferFallback(tripleFallback);
+                        }
+                        uiImLabel(_("Use when advanced blend is unavailable or causes issues."));
                     uiImUnindent();
                 }
                 break;

--- a/source/nijiexpose/windows/spaceedit.d
+++ b/source/nijiexpose/windows/spaceedit.d
@@ -17,6 +17,7 @@ import i18n;
 import std.string;
 import bindbc.imgui;
 import ft;
+static import std.utf;
 
 import std.algorithm.mutation;
 


### PR DESCRIPTION
- Use oglDrawScene instead of old inDrawScene function.
- Add settings to turn on/off emulation blending mode. (emulation blending is currently corrupted in new rendering.)