### PR TITLE
Improve more UX

### DIFF
--- a/source/nijiexpose/panels/scene.d
+++ b/source/nijiexpose/panels/scene.d
@@ -52,14 +52,10 @@ private:
 
 protected:
 
-    override 
-    void onUpdate() {
-
-        
+public:
+    void renderSceneSettingsContent() {
         uiImLabelColored(_("Post Processing"), vec4(0.8, 0.3, 0.3, 1));
         uiImSeperator();
-
-        
         uiImIndent();
             if (uiImCheckbox(__("Enabled###POST_PROCESSING"), insScene.shouldPostProcess)) {
                 inSettingsSet!(bool)("shouldPostProcess", insScene.shouldPostProcess);
@@ -159,6 +155,11 @@ protected:
                 this.loadBackground(null);
             }
         }
+    }
+
+    override 
+    void onUpdate() {
+        renderSceneSettingsContent();
     }
 
 public:

--- a/source/nijiexpose/panels/tracking.d
+++ b/source/nijiexpose/panels/tracking.d
@@ -70,6 +70,7 @@ private:
     }
 
     BindingCardState[] bindingCardStack;
+    BindingCardState[] bindingGroupStack;
 
     string bindingCardTitle(CompoundTrackingBinding.BindingMap item) {
         final switch (item.type) {
@@ -128,30 +129,30 @@ private:
         auto style = igGetStyle();
         auto drawList = state.drawList;
         auto frameBg = style.Colors[ImGuiCol.FrameBg];
-        auto border = ImVec4(0.0f, 0.0f, 0.0f, 0.14f);
-        auto shadow = ImVec4(0.0f, 0.0f, 0.0f, 0.06f);
+        auto border = ImVec4(0.0f, 0.0f, 0.0f, 0.10f);
+        auto shadow = ImVec4(0.0f, 0.0f, 0.0f, 0.035f);
 
         ImDrawList_ChannelsSetCurrent(drawList, 0);
         ImDrawList_AddRectFilled(
             drawList,
             state.startPos,
             ImVec2(state.startPos.x + state.width, endPos.y - 2.0f),
-            igGetColorU32(ImVec4(frameBg.x, frameBg.y, frameBg.z, 0.94f)),
-            6.0f
+            igGetColorU32(ImVec4(frameBg.x, frameBg.y, frameBg.z, 0.55f)),
+            8.0f
         );
         ImDrawList_AddRect(
             drawList,
             state.startPos,
             ImVec2(state.startPos.x + state.width, endPos.y - 2.0f),
             igGetColorU32(border),
-            6.0f
+            8.0f
         );
         if (state.open) {
             ImDrawList_AddLine(
                 drawList,
-                ImVec2(state.startPos.x + 4.0f, state.headerBottom.y),
-                ImVec2(state.startPos.x + state.width - 4.0f, state.headerBottom.y),
-                igGetColorU32(ImVec4(border.x, border.y, border.z, 0.10f)),
+                ImVec2(state.startPos.x + 8.0f, state.headerBottom.y),
+                ImVec2(state.startPos.x + state.width - 8.0f, state.headerBottom.y),
+                igGetColorU32(ImVec4(border.x, border.y, border.z, 0.16f)),
                 1.0f
             );
         }
@@ -160,12 +161,68 @@ private:
             ImVec2(state.startPos.x, endPos.y - 3.0f),
             ImVec2(state.startPos.x + state.width, endPos.y - 1.0f),
             igGetColorU32(shadow),
-            6.0f
+            8.0f
         );
         ImDrawList_ChannelsSetCurrent(drawList, 1);
         ImDrawList_ChannelsMerge(drawList);
 
-        uiImDummy(vec2(0, 4));
+        uiImDummy(vec2(0, 8));
+    }
+
+    bool beginBindingGroup(string title) {
+        auto drawList = igGetWindowDrawList();
+        ImVec2 startPos;
+        igGetCursorScreenPos(&startPos);
+        float width = uiImAvailableSpace().x;
+        bool open = uiImHeader(title.toStringz, true);
+
+        ImVec2 headerBottom;
+        igGetCursorScreenPos(&headerBottom);
+
+        if (open) {
+            uiImIndent();
+            uiImDummy(vec2(0, 2));
+        }
+
+        bindingGroupStack ~= BindingCardState(drawList, startPos, headerBottom, width, open);
+        return open;
+    }
+
+    void endBindingGroup() {
+        if (bindingGroupStack.length == 0) return;
+
+        auto state = bindingGroupStack[$ - 1];
+        bindingGroupStack.length -= 1;
+
+        if (state.open) {
+            uiImDummy(vec2(0, 2));
+            uiImUnindent();
+        }
+
+        ImVec2 endPos;
+        igGetCursorScreenPos(&endPos);
+
+        if (state.open) {
+            auto drawList = state.drawList;
+            auto border = ImVec4(0.0f, 0.0f, 0.0f, 0.10f);
+            auto shadow = ImVec4(0.0f, 0.0f, 0.0f, 0.035f);
+            ImDrawList_AddRect(
+                drawList,
+                ImVec2(state.startPos.x, state.headerBottom.y + 2.0f),
+                ImVec2(state.startPos.x + state.width, endPos.y - 2.0f),
+                igGetColorU32(border),
+                8.0f
+            );
+            ImDrawList_AddRectFilled(
+                drawList,
+                ImVec2(state.startPos.x, endPos.y - 3.0f),
+                ImVec2(state.startPos.x + state.width, endPos.y - 1.0f),
+                igGetColorU32(shadow),
+                8.0f
+            );
+        }
+
+        uiImDummy(vec2(0, 8));
     }
 
     // Refreshes the list of tracking sources
@@ -536,7 +593,7 @@ private:
             int indexToRemove = -1;
             foreach (idx, item; cBinding.bindingMap) {
                 uiImPush(cast(int)idx + 1);
-                if (beginBindingCard(bindingCardTitle(item))) {
+                if (uiImBeginCategory(bindingCardTitle(item).toStringz)) {
                         settingsPopup(&cBinding.bindingMap[idx]);
                         igSameLine();
                         float weight = item.weight;
@@ -564,7 +621,7 @@ private:
                                 break;
                         }
                 }
-                endBindingCard();
+                uiImEndCategory();
                 uiImPop();
             }
             if (indexToRemove >= 0) {
@@ -613,34 +670,33 @@ protected:
 
             foreach(i, ref TrackingBinding binding; item.bindings) {
                 uiImPush(&binding);
-                    if (uiImHeader(binding.name.toStringz, true)) {
-                        uiImIndent();
-                            switch(binding.type) {
+                    if (uiImBeginCategory(binding.name.toStringz)) {
+                        switch(binding.type) {
 
-                                case BindingType.RatioBinding:
-                                    ratioBinding(i, binding.delegated);
-                                    break;
+                            case BindingType.RatioBinding:
+                                ratioBinding(i, binding.delegated);
+                                break;
 
-                                case BindingType.ExpressionBinding:
-                                    exprBinding(i, binding.delegated);
-                                    break;
+                            case BindingType.ExpressionBinding:
+                                exprBinding(i, binding.delegated);
+                                break;
 
-                                case BindingType.EventBinding:
-                                    eventBinding(i, binding.delegated);
-                                    break;
+                            case BindingType.EventBinding:
+                                eventBinding(i, binding.delegated);
+                                break;
 
-                                case BindingType.CompoundBinding:
-                                    compoundBinding(i, binding.delegated);
-                                    break;
+                            case BindingType.CompoundBinding:
+                                compoundBinding(i, binding.delegated);
+                                break;
 
-                                // External bindings
-                                default: 
-                                    settingsPopup(binding);
-                                    uiImLabel(_("No settings available."));
-                                    break;
-                            }
-                        uiImUnindent();
+                            // External bindings
+                            default: 
+                                settingsPopup(binding);
+                                uiImLabel(_("No settings available."));
+                                break;
+                        }
                     }
+                    uiImEndCategory();
                 uiImPop();
             }
         } else uiImLabel(_("No puppet selected"));

--- a/source/nijiexpose/windows/main.d
+++ b/source/nijiexpose/windows/main.d
@@ -820,17 +820,22 @@ private:
             ImVec2 iconPos = ImVec2(headerStart.x, headerStart.y + max(0.0f, (20.0f - iconSize.y) * 0.5f));
             ImDrawList_AddText(drawList, font, headerIconSize, iconPos, igColorConvertFloat4ToU32(ImVec4(ACCENT.x, ACCENT.y, ACCENT.z, ACCENT.w)), headerIcon.toStringz);
             igSetCursorScreenPos(ImVec2(headerStart.x + 30.0f, headerStart.y));
-            uiImLabelColored(title, ACCENT);
+            uiImLabel(title);
             ImVec2 closePos = ImVec2(overlayX + overlayW - 44.0f, headerStart.y);
-            if (drawIconOnlyEntry("overlay_close", "\ue5cd", closePos, 28.0f, vec4(0.12f, 0.16f, 0.23f, 0.90f), true)) {
+            if (drawIconOnlyEntry("overlay_close", "\ue5cd", closePos, 28.0f, vec4(0.12f, 0.16f, 0.23f, 0.90f), false)) {
                 overlayOpen = false;
                 inSettingsSet("ui.overlayOpen", overlayOpen);
             }
             igSetCursorScreenPos(ImVec2(headerStart.x, headerStart.y + 28.0f));
 
-            uiImSeperator();
             if (parameterOverlay) {
                 igSetCursorPosX(0);
+            }
+            igPushStyleColor(ImGuiCol.ChildBg, ImVec4(0, 0, 0, 0));
+            igPushStyleVar(ImGuiStyleVar.ChildBorderSize, 0.0f);
+            scope(exit) {
+                igPopStyleVar();
+                igPopStyleColor();
             }
             if (uiImBeginChild("nijikan_overlay_body###nijikan_overlay_body", vec2(0, 0), false)) {
                 if (active !is null) {

--- a/source/nijiexpose/windows/main.d
+++ b/source/nijiexpose/windows/main.d
@@ -44,13 +44,12 @@ private {
     }
 
     enum ActivePanelId {
-        Scene,
+        Parameters,
         Tracking,
+        View,
         Animations,
         Blendshapes,
         Plugins,
-        Settings,
-        VirtualSpace,
     }
 
     struct NavItem {
@@ -61,13 +60,12 @@ private {
     }
 
     immutable NavItem[] NAV_ITEMS = [
-        NavItem(ActivePanelId.Tracking, "Tracking", "\ue429", "Parameters"),
-        NavItem(ActivePanelId.Scene, "Scene Settings", "\ue8f4", "View"),
+        NavItem(ActivePanelId.Parameters, "Tracking", "\ue429", "Parameters"),
+        NavItem(ActivePanelId.Tracking, "", "\ue3b4", "Tracking"),
+        NavItem(ActivePanelId.View, "Scene Settings", "\ue8f4", "View"),
         NavItem(ActivePanelId.Animations, "Animations", "\ue037", "Animations"),
-        NavItem(ActivePanelId.Blendshapes, "Blendshapes", "\ue3b4", "Blends"),
+        NavItem(ActivePanelId.Blendshapes, "Blendshapes", "\ue3f4", "Blends"),
         NavItem(ActivePanelId.Plugins, "Plugins", "\ue87b", "Plugins"),
-        NavItem(ActivePanelId.Settings, "", "\ue8b8", "Settings"),
-        NavItem(ActivePanelId.VirtualSpace, "", "\ue8d4", "Virtual Space"),
     ];
 
     enum vec4 RAIL_BG = vec4(0.97f, 0.98f, 0.99f, 0.84f);
@@ -127,7 +125,7 @@ private:
     GLint overlayBlurTexelStepLocation = -1;
     int overlayBlurWidth = 0;
     int overlayBlurHeight = 0;
-    ActivePanelId activePanel = ActivePanelId.Scene;
+    ActivePanelId activePanel = ActivePanelId.Parameters;
     bool navExpanded = false;
     bool overlayOpen = true;
     bool navFaded = false;
@@ -135,8 +133,8 @@ private:
     double lastNavInteractionAt = 0;
 
     ActivePanelId sanitizeActivePanel(int rawValue) {
-        if (rawValue < cast(int)ActivePanelId.Scene || rawValue > cast(int)ActivePanelId.VirtualSpace) {
-            return ActivePanelId.Scene;
+        if (rawValue < cast(int)ActivePanelId.Parameters || rawValue > cast(int)ActivePanelId.Plugins) {
+            return ActivePanelId.Parameters;
         }
         return cast(ActivePanelId)rawValue;
     }
@@ -154,12 +152,9 @@ private:
 
     ToolWindow toolWindowFor(ActivePanelId id) {
         final switch(id) {
-        case ActivePanelId.Settings:
-            return settingWindow;
-        case ActivePanelId.VirtualSpace:
-            return spaceEditor;
-        case ActivePanelId.Scene:
+        case ActivePanelId.Parameters:
         case ActivePanelId.Tracking:
+        case ActivePanelId.View:
         case ActivePanelId.Animations:
         case ActivePanelId.Blendshapes:
         case ActivePanelId.Plugins:
@@ -221,7 +216,22 @@ private:
     }
 
     bool usesParameterOverlay(ActivePanelId id) {
-        return id == ActivePanelId.Tracking;
+        return id == ActivePanelId.Parameters;
+    }
+
+    string panelTitle(ActivePanelId id, Panel active, ToolWindow activeWindow) {
+        final switch (id) {
+        case ActivePanelId.Parameters:
+            return "Parameters";
+        case ActivePanelId.Tracking:
+            return "Tracking";
+        case ActivePanelId.View:
+            return "View";
+        case ActivePanelId.Animations:
+        case ActivePanelId.Blendshapes:
+        case ActivePanelId.Plugins:
+            return active !is null ? active.displayName() : (activeWindow !is null ? activeWindow.name() : "");
+        }
     }
 
     void destroyOverlayBlurResources() {
@@ -700,7 +710,7 @@ private:
             }
 
             if (compact) uiImSameLine();
-            drawUtilityButton("\ue2c8", "Open", {
+            drawUtilityButton("\ue2c8", "Models", {
                 const TFD_Filter[] filters = [{ ["*.inp"], "nijilive Puppet (*.inp)" }];
                 string parentWindow = "";
                 version(linux) {
@@ -731,7 +741,9 @@ private:
         if (!showUI || !overlayOpen) return;
         Panel active = panelFor(activePanel);
         ToolWindow activeWindow = toolWindowFor(activePanel);
-        if (active is null && activeWindow is null) return;
+        bool customTracking = activePanel == ActivePanelId.Tracking;
+        bool customView = activePanel == ActivePanelId.View;
+        if (active is null && activeWindow is null && !customTracking && !customView) return;
 
         auto compact = navSurfaceMode() == NavSurfaceMode.CompactBar;
         ImGuiWindowFlags flags = ImGuiWindowFlags.NoCollapse
@@ -785,7 +797,7 @@ private:
         igSetNextWindowPos(ImVec2(overlayX, overlayY), ImGuiCond.Always, ImVec2(0, 0));
         igSetNextWindowSize(ImVec2(overlayW, overlayH), ImGuiCond.Always);
 
-        string title = active !is null ? active.displayName() : activeWindow.name();
+        string title = panelTitle(activePanel, active, activeWindow);
         string windowTitle = "%s###nijikan_overlay_host".format(title);
 
         if (!parameterOverlay && igIsMouseClicked(ImGuiMouseButton.Left)) {
@@ -837,14 +849,38 @@ private:
                 igPopStyleVar();
                 igPopStyleColor();
             }
-            if (uiImBeginChild("nijikan_overlay_body###nijikan_overlay_body", vec2(0, 0), false)) {
-                if (active !is null) {
+            immutable bool hasOverlayFooter = customTracking || customView;
+            immutable float overlayFooterHeight = hasOverlayFooter ? 46.0f : 0.0f;
+            if (uiImBeginChild("nijikan_overlay_body###nijikan_overlay_body", vec2(0, -overlayFooterHeight), false)) {
+                if (customTracking) {
+                    settingWindow.renderTrackingSettingsSection();
+                    uiImSeperator();
+                    spaceEditor.renderEditorSection(false);
+                } else if (customView) {
+                    if (active !is null) {
+                        active.updateEmbedded();
+                    }
+                    uiImSeperator();
+                    settingWindow.renderRenderingSettingsSection();
+                } else if (active !is null) {
                     active.updateEmbedded();
                 } else {
                     activeWindow.updateEmbedded();
                 }
             }
             uiImEndChild();
+            if (hasOverlayFooter) {
+                igDummy(ImVec2(0, 6));
+                igSetCursorPosX(max(0.0f, uiImAvailableSpace().x - 72.0f));
+                if (uiImButton(__("Apply"), vec2(64, 0))) {
+                    if (customTracking) {
+                        settingWindow.applyTrackingSettings();
+                        spaceEditor.applyChanges();
+                    } else if (customView) {
+                        settingWindow.applyRenderingSettings();
+                    }
+                }
+            }
         }
         igEnd();
     }
@@ -938,7 +974,7 @@ public:
         spaceEditor = new SpaceEditor();
         lastPointerPos = inInputMousePosition();
         lastNavInteractionAt = inGetTime();
-        activePanel = sanitizeActivePanel(inSettingsGet!(int)("ui.activePanel", cast(int)ActivePanelId.Scene));
+        activePanel = sanitizeActivePanel(inSettingsGet!(int)("ui.activePanel", cast(int)ActivePanelId.Parameters));
         overlayOpen = inSettingsGet!bool("ui.overlayOpen", true);
 
         // Preload any specified models

--- a/source/nijiexpose/windows/main.d
+++ b/source/nijiexpose/windows/main.d
@@ -14,6 +14,7 @@ import nijiexpose.framesend;
 import nijiexpose.plugins;
 import nijiexpose.io;
 import nijiexpose.io.image;
+import nijiexpose.panels.scene : ScenePanel;
 import nijiexpose.tracking.tracker;
 import nijiui;
 import nijiui.widgets;
@@ -535,6 +536,17 @@ private:
         }
     }
 
+    void drawOverlayBackdrop(float alphaScale = 1.0f) {
+        if (alphaScale <= 0.0f) return;
+        auto bgDrawList = igGetBackgroundDrawList_Nil();
+        ImDrawList_AddRectFilled(
+            bgDrawList,
+            ImVec2(0.0f, 0.0f),
+            ImVec2(cast(float)width, cast(float)height),
+            igColorConvertFloat4ToU32(ImVec4(0.58f, 0.64f, 0.72f, 0.10f * alphaScale))
+        );
+    }
+
     string iconFor(ActivePanelId id) {
         foreach (item; NAV_ITEMS) {
             if (item.id == id) {
@@ -780,14 +792,15 @@ private:
         }
 
         {
-            drawBlurBackdrop(overlayX, overlayY, overlayW, overlayH, 18.0f);
-            drawSoftWindowShadow(overlayX, overlayY, overlayW, overlayH, 18.0f);
+            drawOverlayBackdrop(1.0f);
+            drawBlurBackdrop(overlayX, overlayY, overlayW, overlayH, 13.0f);
+            drawSoftWindowShadow(overlayX, overlayY, overlayW, overlayH, 13.0f);
         }
 
         igPushStyleColor(ImGuiCol.WindowBg, ImVec4(OVERLAY_BG.x, OVERLAY_BG.y, OVERLAY_BG.z, OVERLAY_BG.w));
         igPushStyleColor(ImGuiCol.Border, ImVec4(OVERLAY_BORDER.x, OVERLAY_BORDER.y, OVERLAY_BORDER.z, OVERLAY_BORDER.w));
         igPushStyleVar(ImGuiStyleVar.WindowBorderSize, 1.0f);
-        igPushStyleVar(ImGuiStyleVar.WindowPadding, parameterOverlay ? ImVec2(0, 0) : ImVec2(16, 14));
+        igPushStyleVar(ImGuiStyleVar.WindowPadding, parameterOverlay ? ImVec2(0, 0) : ImVec2(18, 16));
         igPushStyleVar(ImGuiStyleVar.WindowRounding, 13.0f);
         scope(exit) {
             igPopStyleVar(3);
@@ -833,35 +846,49 @@ private:
             ImDrawList_AddText(drawList, font, headerIconSize, iconPos, igColorConvertFloat4ToU32(ImVec4(ACCENT.x, ACCENT.y, ACCENT.z, ACCENT.w)), headerIcon.toStringz);
             igSetCursorScreenPos(ImVec2(headerStart.x + 30.0f, headerStart.y));
             uiImLabel(title);
-            ImVec2 closePos = ImVec2(overlayX + overlayW - 44.0f, headerStart.y);
+            ImVec2 closePos = ImVec2(overlayX + overlayW - 42.0f, headerStart.y - 2.0f);
             if (drawIconOnlyEntry("overlay_close", "\ue5cd", closePos, 28.0f, vec4(0.12f, 0.16f, 0.23f, 0.90f), false)) {
                 overlayOpen = false;
                 inSettingsSet("ui.overlayOpen", overlayOpen);
             }
-            igSetCursorScreenPos(ImVec2(headerStart.x, headerStart.y + 28.0f));
+            igSetCursorScreenPos(ImVec2(headerStart.x, headerStart.y + 32.0f));
 
             if (parameterOverlay) {
                 igSetCursorPosX(0);
             }
             igPushStyleColor(ImGuiCol.ChildBg, ImVec4(0, 0, 0, 0));
             igPushStyleVar(ImGuiStyleVar.ChildBorderSize, 0.0f);
+            igPushStyleVar(ImGuiStyleVar.ItemSpacing, parameterOverlay ? ImVec2(8, 6) : ImVec2(8, 8));
             scope(exit) {
+                igPopStyleVar();
                 igPopStyleVar();
                 igPopStyleColor();
             }
             immutable bool hasOverlayFooter = customTracking || customView;
-            immutable float overlayFooterHeight = hasOverlayFooter ? 46.0f : 0.0f;
+            immutable float overlayFooterHeight = hasOverlayFooter ? 48.0f : 0.0f;
             if (uiImBeginChild("nijikan_overlay_body###nijikan_overlay_body", vec2(0, -overlayFooterHeight), false)) {
                 if (customTracking) {
-                    settingWindow.renderTrackingSettingsSection();
+                    uiImLabel(_("Tracking Settings"));
+                    igDummy(ImVec2(0, 4));
+                    settingWindow.renderTrackingSettingsContent(true);
                     uiImSeperator();
-                    spaceEditor.renderEditorSection(false);
+                    uiImNewLine();
+                    uiImLabel(_("Virtual Space"));
+                    igDummy(ImVec2(0, 4));
+                    spaceEditor.renderEmbeddedSection();
                 } else if (customView) {
-                    if (active !is null) {
+                    uiImLabel(_("Scene Settings"));
+                    igDummy(ImVec2(0, 4));
+                    if (auto scenePanel = cast(ScenePanel)active) {
+                        scenePanel.renderSceneSettingsContent();
+                    } else if (active !is null) {
                         active.updateEmbedded();
                     }
                     uiImSeperator();
-                    settingWindow.renderRenderingSettingsSection();
+                    uiImNewLine();
+                    uiImLabel(_("Rendering"));
+                    igDummy(ImVec2(0, 4));
+                    settingWindow.renderRenderingSettingsContent(true);
                 } else if (active !is null) {
                     active.updateEmbedded();
                 } else {
@@ -870,7 +897,7 @@ private:
             }
             uiImEndChild();
             if (hasOverlayFooter) {
-                igDummy(ImVec2(0, 6));
+                igDummy(ImVec2(0, 4));
                 igSetCursorPosX(max(0.0f, uiImAvailableSpace().x - 72.0f));
                 if (uiImButton(__("Apply"), vec2(64, 0))) {
                     if (customTracking) {

--- a/source/nijiexpose/windows/settings.d
+++ b/source/nijiexpose/windows/settings.d
@@ -101,8 +101,15 @@ public:
         vec2 avail = uiImAvailableSpace();
         float lhs = 196;
         float rhs = avail.x-lhs;
+        immutable float footerHeight = 38.0f;
+        igPushStyleColor(ImGuiCol.ChildBg, ImVec4(1, 1, 1, 0));
+        igPushStyleVar(ImGuiStyleVar.ChildBorderSize, 0.0f);
+        scope(exit) {
+            igPopStyleVar();
+            igPopStyleColor();
+        }
 
-        if (uiImBeginChild("##LHS", vec2(lhs, -28), true)) {
+        if (uiImBeginChild("##LHS", vec2(lhs, -footerHeight), false)) {
             avail = uiImAvailableSpace();
             uiImPush(0);
             if (uiImSelectable(__("Tracking"), selected == SelectedMode.Tracking)) {
@@ -117,7 +124,7 @@ public:
 
         uiImSameLine(0, 0);
 
-        if (uiImBeginChild("##RHS", vec2(rhs, -28), true)) {
+        if (uiImBeginChild("##RHS", vec2(rhs, -footerHeight), false)) {
             avail = uiImAvailableSpace();
             switch (selected) {
             case SelectedMode.Tracking:
@@ -215,8 +222,7 @@ public:
         }
         uiImEndChild();
 
-        uiImDummy(vec2(-64, 0));
-        uiImSameLine(0, 0);
+        igSetCursorPosX(max(0.0f, uiImAvailableSpace().x - 72.0f));
         if (uiImButton(__("Apply"), vec2(64, 0))) {
             applySettings();
         }

--- a/source/nijiexpose/windows/settings.d
+++ b/source/nijiexpose/windows/settings.d
@@ -105,83 +105,111 @@ public:
         Rendering
     }
 
-    void renderTrackingSettingsSection() {
+    void renderTrackingSettingsContent(bool embedded) {
         ensureDraftLoaded();
         auto tracker = trackerDraft;
-        if (uiImHeader(__("Tracking"), true)) {
-            uiImIndent();
-                uiImCheckbox(__("Enable tracking"), tracker.enabled);
-                if (tracker.enabled) {
-                    tracker.update();
-                    if (uiImBeginCategory("##tracker")) {
-                        uiImLabel(_("Python path"));
-                        uiImSameLine();
-                        if (!pythonPathTested) {
-                            pythonPath = PythonProcess!false.detectPython();
-                            pythonPathTested = true;
-                        }
-                        if (pythonPath is null) {
-                            uiImLabelColored(_("Python is not detected. Please install python (<=3.12) first."), vec4(0.9, 0.5, 0.5, 1));
-                        } else {
-                            uiImLabel(pythonPath);
-                        }
-                        uiImLabel(_("Tracker executable path"));
-                        uiImSameLine();
-                        uiImInputText("##trackerPath", tracker.trackerPath);
-                        if (!tracker.scriptPath.exists) {
-                            uiImLabelColored(_("Specified path doesn't contain %s").format(tracker.trackerScriptName), vec4(0.95, 0.5, 0.5, 1));
-                            uiImSameLine();
-                            if (uiImButton(__("Install"))) {
-                                tracker.install();
-                            }
-                        } else if (tracker.installProcess !is null) {
-                            tracker.installProcess.update();
-                            auto outputText = tracker.installProcess.stdoutOutput.join("\n");
-                            vec2 avail2 = uiImAvailableSpace();
-                            vec2 logAreaSize = vec2(avail2.x, avail2.y - 50);
-                            if (uiImBeginChild("##log_area", logAreaSize, true)) {
-                                igTextUnformatted(outputText.toStringz);
-                                uiImEndChild();
-                            }
-                            if (!tracker.installProcess.running()) {
-                                if (uiImButton(__("OK"))) {
-                                    tracker.installProcess = null;
-                                }
-                            }
-                        } else {
-                            uiImLabel(_("Camera device"));
-                            uiImSameLine();
-                            auto deviceList = tracker.listDevices();
-                            long currentDeviceId = deviceList.countUntil!(x=>x.id == tracker.device)();
-                            string currentDeviceName = (currentDeviceId >= 0)? deviceList[currentDeviceId].name: _("Select device...");
-                            if (igBeginCombo("##device", currentDeviceName.toStringz ,ImGuiComboFlags.None)) {
-                                if (deviceList !is null) {
-                                    foreach (device; deviceList) {
-                                        if (uiImSelectable(device.name.toStringz, device.id == tracker.device)) {
-                                            tracker.device = device.id;
-                                        }
-                                    }
-                                }
-                                igEndCombo();
-                            }
-                            uiImLabel(_("Host name"));
-                            uiImSameLine();
-                            uiImInputText("##host", tracker.hostname);
-                            uiImLabel(_("Port number"));
-                            uiImSameLine();
-                            igInputInt("##PortNumber", cast(int*)&tracker.port);
-                            uiImCheckbox(__("Flip input"), tracker.flipped);
-                            uiImCheckbox(__("Show camera tracking window"), tracker.showWindow);
+        uiImCheckbox(__("Enable tracking"), tracker.enabled);
+        if (tracker.enabled) {
+            tracker.update();
+            if (!embedded || uiImBeginCategory("##tracker")) {
+                uiImLabel(_("Python path"));
+                uiImSameLine();
+                if (!pythonPathTested) {
+                    pythonPath = PythonProcess!false.detectPython();
+                    pythonPathTested = true;
+                }
+                if (pythonPath is null) {
+                    uiImLabelColored(_("Python is not detected. Please install python (<=3.12) first."), vec4(0.9, 0.5, 0.5, 1));
+                } else {
+                    uiImLabel(pythonPath);
+                }
+                uiImLabel(_("Tracker executable path"));
+                uiImSameLine();
+                uiImInputText("##trackerPath", tracker.trackerPath);
+                if (!tracker.scriptPath.exists) {
+                    uiImLabelColored(_("Specified path doesn't contain %s").format(tracker.trackerScriptName), vec4(0.95, 0.5, 0.5, 1));
+                    uiImSameLine();
+                    if (uiImButton(__("Install"))) {
+                        tracker.install();
+                    }
+                } else if (tracker.installProcess !is null) {
+                    tracker.installProcess.update();
+                    auto outputText = tracker.installProcess.stdoutOutput.join("\n");
+                    vec2 avail2 = uiImAvailableSpace();
+                    vec2 logAreaSize = vec2(avail2.x, avail2.y - 50);
+                    if (uiImBeginChild("##log_area", logAreaSize, true)) {
+                        igTextUnformatted(outputText.toStringz);
+                        uiImEndChild();
+                    }
+                    if (!tracker.installProcess.running()) {
+                        if (uiImButton(__("OK"))) {
+                            tracker.installProcess = null;
                         }
                     }
+                } else {
+                    uiImLabel(_("Camera device"));
+                    uiImSameLine();
+                    auto deviceList = tracker.listDevices();
+                    long currentDeviceId = deviceList.countUntil!(x=>x.id == tracker.device)();
+                    string currentDeviceName = (currentDeviceId >= 0)? deviceList[currentDeviceId].name: _("Select device...");
+                    if (igBeginCombo("##device", currentDeviceName.toStringz ,ImGuiComboFlags.None)) {
+                        if (deviceList !is null) {
+                            foreach (device; deviceList) {
+                                if (uiImSelectable(device.name.toStringz, device.id == tracker.device)) {
+                                    tracker.device = device.id;
+                                }
+                            }
+                        }
+                        igEndCombo();
+                    }
+                    uiImLabel(_("Host name"));
+                    uiImSameLine();
+                    uiImInputText("##host", tracker.hostname);
+                    uiImLabel(_("Port number"));
+                    uiImSameLine();
+                    igInputInt("##PortNumber", cast(int*)&tracker.port);
+                    uiImCheckbox(__("Flip input"), tracker.flipped);
+                    uiImCheckbox(__("Show camera tracking window"), tracker.showWindow);
+                }
+                if (embedded) {
+                    igDummy(ImVec2(0, 4));
+                } else {
                     uiImEndCategory();
                 }
+            }
+        }
+    }
+
+    void renderTrackingSettingsSection() {
+        if (uiImHeader(__("Tracking"), true)) {
+            uiImIndent();
+                renderTrackingSettingsContent(false);
             uiImUnindent();
         }
     }
 
-    void renderRenderingSettingsSection() {
+    void renderRenderingSettingsContent(bool embedded) {
         ensureDraftLoaded();
+        if (embedded) {
+            uiImLabelColored(_("V-Sync throttling"), vec4(0.8, 0.3, 0.3, 1));
+            uiImSeperator();
+            uiImIndent();
+                uiImLabel("%s (%s)".format(_("Throtting interval"), _("Experimental")));
+                igSliderInt("##THROTTLING", &throttlingDraft, 0, 6);
+                uiImSameLine();
+                uiImLabel(_("Frame rate: %.2f fps".format(neGetFPS())));
+            uiImUnindent();
+            igDummy(ImVec2(0, 6));
+
+            uiImLabelColored(_("Triple buffer fallback"), vec4(0.8, 0.3, 0.3, 1));
+            uiImSeperator();
+            uiImIndent();
+                uiImCheckbox(__("Enable triple buffer fallback"), tripleFallbackDraft);
+                uiImLabel(_("Use when advanced blend is unavailable or causes issues."));
+            uiImUnindent();
+            return;
+        }
+
         if (uiImHeader(__("V-Sync throttling"), true)) {
             uiImIndent();
                 uiImLabel("%s (%s)".format(_("Throtting interval"), _("Experimental")));
@@ -196,6 +224,10 @@ public:
                 uiImLabel(_("Use when advanced blend is unavailable or causes issues."));
             uiImUnindent();
         }
+    }
+
+    void renderRenderingSettingsSection() {
+        renderRenderingSettingsContent(false);
     }
 
     override

--- a/source/nijiexpose/windows/settings.d
+++ b/source/nijiexpose/windows/settings.d
@@ -49,15 +49,12 @@ private:
         trackerDraftLoaded = true;
     }
 
-    void applySettings() {
+public:
+    void applyTrackingSettings() {
         ensureDraftLoaded();
         auto tracker = neTracker();
         copyTrackerState(tracker, trackerDraft);
         inSettingsSet("tracker", tracker);
-        inSettingsSet("throttlingRate", throttlingDraft);
-        neWindowSetThrottlingRate(throttlingDraft);
-        inSettingsSet("TripleBufferFallback", tripleFallbackDraft);
-        nlSetTripleBufferFallback(tripleFallbackDraft);
         inSettingsSave();
         if (tracker.enabled) {
             tracker.restart();
@@ -66,7 +63,20 @@ private:
             tracker.terminate();
         }
     }
-public:
+
+    void applyRenderingSettings() {
+        ensureDraftLoaded();
+        inSettingsSet("throttlingRate", throttlingDraft);
+        neWindowSetThrottlingRate(throttlingDraft);
+        inSettingsSet("TripleBufferFallback", tripleFallbackDraft);
+        nlSetTripleBufferFallback(tripleFallbackDraft);
+        inSettingsSave();
+    }
+
+    void applySettings() {
+        applyTrackingSettings();
+        applyRenderingSettings();
+    }
     SelectedMode selected = SelectedMode.Tracking;
     string pythonPath = null;
     bool pythonPathTested = false;
@@ -93,6 +103,99 @@ public:
     enum SelectedMode {
         Tracking,
         Rendering
+    }
+
+    void renderTrackingSettingsSection() {
+        ensureDraftLoaded();
+        auto tracker = trackerDraft;
+        if (uiImHeader(__("Tracking"), true)) {
+            uiImIndent();
+                uiImCheckbox(__("Enable tracking"), tracker.enabled);
+                if (tracker.enabled) {
+                    tracker.update();
+                    if (uiImBeginCategory("##tracker")) {
+                        uiImLabel(_("Python path"));
+                        uiImSameLine();
+                        if (!pythonPathTested) {
+                            pythonPath = PythonProcess!false.detectPython();
+                            pythonPathTested = true;
+                        }
+                        if (pythonPath is null) {
+                            uiImLabelColored(_("Python is not detected. Please install python (<=3.12) first."), vec4(0.9, 0.5, 0.5, 1));
+                        } else {
+                            uiImLabel(pythonPath);
+                        }
+                        uiImLabel(_("Tracker executable path"));
+                        uiImSameLine();
+                        uiImInputText("##trackerPath", tracker.trackerPath);
+                        if (!tracker.scriptPath.exists) {
+                            uiImLabelColored(_("Specified path doesn't contain %s").format(tracker.trackerScriptName), vec4(0.95, 0.5, 0.5, 1));
+                            uiImSameLine();
+                            if (uiImButton(__("Install"))) {
+                                tracker.install();
+                            }
+                        } else if (tracker.installProcess !is null) {
+                            tracker.installProcess.update();
+                            auto outputText = tracker.installProcess.stdoutOutput.join("\n");
+                            vec2 avail2 = uiImAvailableSpace();
+                            vec2 logAreaSize = vec2(avail2.x, avail2.y - 50);
+                            if (uiImBeginChild("##log_area", logAreaSize, true)) {
+                                igTextUnformatted(outputText.toStringz);
+                                uiImEndChild();
+                            }
+                            if (!tracker.installProcess.running()) {
+                                if (uiImButton(__("OK"))) {
+                                    tracker.installProcess = null;
+                                }
+                            }
+                        } else {
+                            uiImLabel(_("Camera device"));
+                            uiImSameLine();
+                            auto deviceList = tracker.listDevices();
+                            long currentDeviceId = deviceList.countUntil!(x=>x.id == tracker.device)();
+                            string currentDeviceName = (currentDeviceId >= 0)? deviceList[currentDeviceId].name: _("Select device...");
+                            if (igBeginCombo("##device", currentDeviceName.toStringz ,ImGuiComboFlags.None)) {
+                                if (deviceList !is null) {
+                                    foreach (device; deviceList) {
+                                        if (uiImSelectable(device.name.toStringz, device.id == tracker.device)) {
+                                            tracker.device = device.id;
+                                        }
+                                    }
+                                }
+                                igEndCombo();
+                            }
+                            uiImLabel(_("Host name"));
+                            uiImSameLine();
+                            uiImInputText("##host", tracker.hostname);
+                            uiImLabel(_("Port number"));
+                            uiImSameLine();
+                            igInputInt("##PortNumber", cast(int*)&tracker.port);
+                            uiImCheckbox(__("Flip input"), tracker.flipped);
+                            uiImCheckbox(__("Show camera tracking window"), tracker.showWindow);
+                        }
+                    }
+                    uiImEndCategory();
+                }
+            uiImUnindent();
+        }
+    }
+
+    void renderRenderingSettingsSection() {
+        ensureDraftLoaded();
+        if (uiImHeader(__("V-Sync throttling"), true)) {
+            uiImIndent();
+                uiImLabel("%s (%s)".format(_("Throtting interval"), _("Experimental")));
+                igSliderInt("##THROTTLING", &throttlingDraft, 0, 6);
+                uiImSameLine();
+                uiImLabel(_("Frame rate: %.2f fps".format(neGetFPS())));
+            uiImUnindent();
+        }
+        if (uiImHeader(__("Triple buffer fallback"), true)) {
+            uiImIndent();
+                uiImCheckbox(__("Enable triple buffer fallback"), tripleFallbackDraft);
+                uiImLabel(_("Use when advanced blend is unavailable or causes issues."));
+            uiImUnindent();
+        }
     }
 
     override
@@ -125,99 +228,13 @@ public:
         uiImSameLine(0, 0);
 
         if (uiImBeginChild("##RHS", vec2(rhs, -footerHeight), false)) {
-            avail = uiImAvailableSpace();
-            switch (selected) {
+            final switch (selected) {
             case SelectedMode.Tracking:
-                if (uiImHeader(__("Tracking"), true)) {
-                    uiImIndent();
-                        auto tracker = trackerDraft;
-                        uiImCheckbox(__("Enable tracking"), tracker.enabled);
-                        if (tracker.enabled) {
-                            tracker.update();
-                            if (uiImBeginCategory("##tracker")) {
-                                uiImLabel(_("Python path"));
-                                uiImSameLine();
-                                if (!pythonPathTested) {
-                                    pythonPath = PythonProcess!false.detectPython();
-                                    pythonPathTested = true;
-                                }
-                                if (pythonPath is null) {
-                                    uiImLabelColored(_("Python is not detected. Please install python (<=3.12) first."), vec4(0.9, 0.5, 0.5, 1));
-                                } else {
-                                    uiImLabel(pythonPath);
-                                }
-                                uiImLabel(_("Tracker executable path"));
-                                uiImSameLine();
-                                uiImInputText("##trackerPath", tracker.trackerPath);
-                                if (!tracker.scriptPath.exists) {
-                                    uiImLabelColored(_("Specified path doesn't contain %s").format(tracker.trackerScriptName), vec4(0.95, 0.5, 0.5, 1));
-                                    uiImSameLine();
-                                    if (uiImButton(__("Install"))) {
-                                        tracker.install();
-                                    }
-                                } else if (tracker.installProcess !is null) {
-                                    tracker.installProcess.update();
-                                    auto outputText = tracker.installProcess.stdoutOutput.join("\n");
-                                    vec2 avail2 = uiImAvailableSpace();
-                                    vec2 logAreaSize = vec2(avail2.x, avail2.y - 50);
-                                    if (uiImBeginChild("##log_area", logAreaSize, true)) {
-                                        igTextUnformatted(outputText.toStringz);
-                                        uiImEndChild();
-                                    }
-                                    if (!tracker.installProcess.running()) {
-                                        if (uiImButton(__("OK"))) {
-                                            tracker.installProcess = null;
-                                        }
-                                    }
-                                } else {
-                                    uiImLabel(_("Camera device"));
-                                    uiImSameLine();
-                                    auto deviceList = tracker.listDevices();
-                                    long currentDeviceId = deviceList.countUntil!(x=>x.id == tracker.device)();
-                                    string currentDeviceName = (currentDeviceId >= 0)? deviceList[currentDeviceId].name: _("Select device...");
-                                    if (igBeginCombo("##device", currentDeviceName.toStringz ,ImGuiComboFlags.None)) {
-                                        if (deviceList !is null) {
-                                            foreach (device; deviceList) {
-                                                if (uiImSelectable(device.name.toStringz, device.id == tracker.device)) {
-                                                    tracker.device = device.id;
-                                                }
-                                            }
-                                        }
-                                        igEndCombo();
-                                    }
-                                    uiImLabel(_("Host name"));
-                                    uiImSameLine();
-                                    uiImInputText("##host", tracker.hostname);
-                                    uiImLabel(_("Port number"));
-                                    uiImSameLine();
-                                    igInputInt("##PortNumber", cast(int*)&tracker.port);
-                                    uiImCheckbox(__("Flip input"), tracker.flipped);
-                                    uiImCheckbox(__("Show camera tracking window"), tracker.showWindow);
-                                }
-                            }
-                            uiImEndCategory();
-                        }
-                    uiImUnindent();
-                }
+                renderTrackingSettingsSection();
                 break;
             case SelectedMode.Rendering:
-                if (uiImHeader(__("V-Sync throttling"), true)) {
-                    uiImIndent();
-                        uiImLabel("%s (%s)".format(_("Throtting interval"), _("Experimental")));
-
-                        igSliderInt("##THROTTLING", &throttlingDraft, 0, 6);
-                        uiImSameLine();
-                        uiImLabel(_("Frame rate: %.2f fps".format(neGetFPS())));
-                    uiImUnindent();
-                }
-                if (uiImHeader(__("Triple buffer fallback"), true)) {
-                    uiImIndent();
-                        uiImCheckbox(__("Enable triple buffer fallback"), tripleFallbackDraft);
-                        uiImLabel(_("Use when advanced blend is unavailable or causes issues."));
-                    uiImUnindent();
-                }
+                renderRenderingSettingsSection();
                 break;
-            default:
             }
         }
         uiImEndChild();

--- a/source/nijiexpose/windows/spaceedit.d
+++ b/source/nijiexpose/windows/spaceedit.d
@@ -21,6 +21,7 @@ import ft;
 static import std.utf;
 
 import std.algorithm.mutation;
+import std.algorithm.comparison : max;
 
 class SpaceEditor : ToolWindow {
 private:
@@ -215,8 +216,15 @@ public:
         vec2 avail = uiImAvailableSpace();
         float lhs = 196;
         float rhs = avail.x-lhs;
+        immutable float footerHeight = 38.0f;
+        igPushStyleColor(ImGuiCol.ChildBg, ImVec4(1, 1, 1, 0));
+        igPushStyleVar(ImGuiStyleVar.ChildBorderSize, 0.0f);
+        scope(exit) {
+            igPopStyleVar();
+            igPopStyleColor();
+        }
 
-        if (uiImBeginChild("##LHS", vec2(lhs, -28), true)) {
+        if (uiImBeginChild("##LHS", vec2(lhs, -footerHeight), false)) {
             avail = uiImAvailableSpace();
             foreach(i, ref VirtualSpaceZone zone; insScene.space.getZones()) {
                 uiImPush(cast(int)i);
@@ -240,7 +248,7 @@ public:
 
         uiImSameLine(0, 0);
 
-        if (uiImBeginChild("##RHS", vec2(rhs, -28), true)) {
+        if (uiImBeginChild("##RHS", vec2(rhs, -footerHeight), false)) {
             if (editingZone is null) {
                 uiImLabel(_("No zone selected for editing..."));
             } else {
@@ -334,8 +342,7 @@ public:
         }
         uiImEndChild();
 
-        uiImDummy(vec2(-64, 0));
-        uiImSameLine(0, 0);
+        igSetCursorPosX(max(0.0f, uiImAvailableSpace().x - 72.0f));
         if (uiImButton(__("Apply"), vec2(64, 0))) {
             applyChanges();
         }

--- a/source/nijiexpose/windows/spaceedit.d
+++ b/source/nijiexpose/windows/spaceedit.d
@@ -1,8 +1,8 @@
 /*
-    Copyright © 2022, Inochi2D Project
-    Copyright © 2024, nijigenerate Project
+    Copyright ﾂｩ 2022, Inochi2D Project
+    Copyright ﾂｩ 2024, nijigenerate Project
     Distributed under the 2-Clause BSD License, see LICENSE file.
-    
+
     Authors: Luna Nielsen
 */
 module nijiexpose.windows.spaceedit;
@@ -27,15 +27,7 @@ class SpaceEditor : ToolWindow {
 private:
     VirtualSpaceZone editingZone;
     string newZoneName;
-    void applyChanges() {
-        insScene.space.refresh();
-        insSaveVSpace(insScene.space);
-        neTrackingPanelReset();
-        insTrackingPanelRefresh();
-        if (neTracker.enabled) {
-            neTracker.setupVSpace();
-        }
-    }
+    string[string][Adaptor] options;
 
     void addZone() {
         if (newZoneName.length == 0) {
@@ -57,20 +49,16 @@ private:
 
     void refreshOptionsList() {
         options.clear();
+        if (editingZone is null) return;
 
-        foreach(i; 0..editingZone.sources.length) {
-
+        foreach (i; 0 .. editingZone.sources.length) {
             if (editingZone.sources[i] is null) continue;
-            
             options[editingZone.sources[i]] = editingZone.sources[i].getOptions();
             options[editingZone.sources[i]]["appName"] = "nijiexpose";
         }
     }
 
-    string[string][Adaptor] options;
-
     void adaptorDelete(size_t idx) {
-        // stop source on delete
         if (editingZone.sources[idx]) editingZone.sources[idx].stop();
         editingZone.sources = editingZone.sources.remove(idx);
     }
@@ -88,12 +76,9 @@ private:
     void zoneMenu(size_t idx) {
         uiImRightClickPopup("AdaptorPopup");
 
-
         if (uiImBeginPopup("AdaptorPopup")) {
             if (uiImMenuItem(__("Delete"))) {
-                
-                // stop ALL sources on delete
-                foreach(ref source; insScene.space.getZones()[idx].sources) {
+                foreach (ref source; insScene.space.getZones()[idx].sources) {
                     if (source) source.stop();
                 }
                 insScene.space.removeZoneAt(idx);
@@ -102,61 +87,50 @@ private:
         }
     }
 
-    /**
-        this function show hints to help users to configure the adaptor correctly
-    */
     void adaptorHint(ref Adaptor source) {
-        /**
-            for port binding information, we should refer to `facetrack-d/source/ft/adaptors/*.d`
-        */
-
         string portHint = "";
-        if (auto vts = cast(IFMAdaptor) source)
+        if (auto vts = cast(IFMAdaptor)source) {
             portHint = _("iFacialMocap Adpator would listen on udp port 49983");
-        if (portHint.length > 0)
+        }
+        if (portHint.length > 0) {
             uiImLabel(portHint ~ "\n" ~ _("Make sure the port is not blocked by firewall."));
+        }
     }
 
     void adaptorSelect(size_t i, ref Adaptor source, const(char)* adaptorName) {
         if (uiImBeginComboBox("ADAPTOR_COMBO", adaptorName)) {
             if (uiImSelectable("VTubeStudio")) {
                 if (source) source.stop();
-                
                 source = new VTSAdaptor();
                 editingZone.sources[i] = source;
                 refreshOptionsList();
             }
             if (uiImSelectable("VMC")) {
                 if (source) source.stop();
-
                 source = new VMCAdaptor();
                 editingZone.sources[i] = source;
                 refreshOptionsList();
             }
             if (uiImSelectable("Phiz OSC")) {
                 if (source) source.stop();
-
                 source = new PhizOSCAdaptor();
                 editingZone.sources[i] = source;
                 refreshOptionsList();
             }
             if (uiImSelectable("OpenSeeFace")) {
                 if (source) source.stop();
-
                 source = new OSFAdaptor();
                 editingZone.sources[i] = source;
                 refreshOptionsList();
             }
             if (uiImSelectable("iFacialMocap")) {
                 if (source) source.stop();
-
                 source = new IFMAdaptor();
                 editingZone.sources[i] = source;
                 refreshOptionsList();
             }
             if (uiImSelectable("Facemotion3D")) {
                 if (source) source.stop();
-
                 source = new FM3DAdaptor();
                 editingZone.sources[i] = source;
                 refreshOptionsList();
@@ -164,7 +138,6 @@ private:
             version (WebHookAdaptor) {
                 if (uiImSelectable("WebHook Receiver")) {
                     if (source) source.stop();
-
                     source = new WebHookAdaptor();
                     editingZone.sources[i] = source;
                     refreshOptionsList();
@@ -173,7 +146,6 @@ private:
             version (Phiz) {
                 if (uiImSelectable("Phiz Receiver")) {
                     if (source) source.stop();
-
                     source = new PhizAdaptor();
                     editingZone.sources[i] = source;
                     refreshOptionsList();
@@ -182,7 +154,6 @@ private:
             version (JML) {
                 if (uiImSelectable("JINS MEME Logger")) {
                     if (source) source.stop();
-
                     source = new JMLAdaptor();
                     editingZone.sources[i] = source;
                     refreshOptionsList();
@@ -193,30 +164,22 @@ private:
     }
 
 public:
-    override
-    void onBeginUpdate() {
-        ImVec2 wpos = ImVec2(
-            igGetMainViewport().Pos.x+(igGetMainViewport().Size.x/2),
-            igGetMainViewport().Pos.y+(igGetMainViewport().Size.y/2),
-        );
-
-        ImVec2 uiSize = ImVec2(
-            800, 
-            600
-        );
-
-        igSetNextWindowPos(wpos, ImGuiCond.Appearing, ImVec2(0.5, 0.5));
-        igSetNextWindowSize(uiSize, ImGuiCond.Appearing);
-        igSetNextWindowSizeConstraints(uiSize, ImVec2(float.max, float.max));
-        super.onBeginUpdate();
+    void applyChanges() {
+        insScene.space.refresh();
+        insSaveVSpace(insScene.space);
+        neTrackingPanelReset();
+        insTrackingPanelRefresh();
+        if (neTracker.enabled) {
+            neTracker.setupVSpace();
+        }
     }
 
-    override
-    void onUpdate() {
+    void renderEditorSection(bool showApplyButton = false) {
         vec2 avail = uiImAvailableSpace();
         float lhs = 196;
-        float rhs = avail.x-lhs;
-        immutable float footerHeight = 38.0f;
+        float rhs = avail.x - lhs;
+        immutable float footerHeight = showApplyButton ? 38.0f : 0.0f;
+
         igPushStyleColor(ImGuiCol.ChildBg, ImVec4(1, 1, 1, 0));
         igPushStyleVar(ImGuiStyleVar.ChildBorderSize, 0.0f);
         scope(exit) {
@@ -226,7 +189,7 @@ public:
 
         if (uiImBeginChild("##LHS", vec2(lhs, -footerHeight), false)) {
             avail = uiImAvailableSpace();
-            foreach(i, ref VirtualSpaceZone zone; insScene.space.getZones()) {
+            foreach (i, ref VirtualSpaceZone zone; insScene.space.getZones()) {
                 uiImPush(cast(int)i);
                     if (uiImSelectable(zone.name.toStringz, zone == editingZone)) {
                         switchZone(zone);
@@ -236,13 +199,13 @@ public:
             }
 
             string editingZoneName = newZoneName.dup;
-            if (uiImInputText("###ZONE_NAME", avail.x-24, editingZoneName)) {
+            if (uiImInputText("###ZONE_NAME", avail.x - 24, editingZoneName)) {
                 try {
                     newZoneName = editingZoneName.toStringz.fromStringz;
                 } catch (std.utf.UTFException e) {}
             }
             uiImSameLine(0, 0);
-            if (uiImButton(__(""), vec2(24, 24))) addZone();
+            if (uiImButton(__("\ue145"), vec2(24, 24))) addZone();
         }
         uiImEndChild();
 
@@ -254,7 +217,7 @@ public:
             } else {
                 uiImPush(cast(int)editingZone.hashOf());
                     string editingZoneName = editingZone.name;
-                    if (uiImInputText("###ZoneName", avail.x/2, editingZoneName)) {
+                    if (uiImInputText("###ZoneName", avail.x / 2, editingZoneName)) {
                         try {
                             editingZone.name = editingZoneName.toStringz.fromStringz;
                         } catch (std.utf.UTFException e) {}
@@ -264,11 +227,8 @@ public:
                     uiImNewLine();
 
                     uiImIndent();
-                        foreach(i; 0..editingZone.sources.length) {
-                            // Deleting a source causes some confusion here.
-                            if (i >= editingZone.sources.length) {
-                                continue;
-                            }
+                        foreach (i; 0 .. editingZone.sources.length) {
+                            if (i >= editingZone.sources.length) continue;
 
                             uiImPush(cast(int)i);
                                 auto source = editingZone.sources[i];
@@ -288,21 +248,17 @@ public:
                                         adaptorMenu(i);
                                         uiImIndent();
                                             avail = uiImAvailableSpace();
-                                            
                                             adaptorSelect(i, source, adaptorName);
-
                                             igNewLine();
 
-                                            foreach(option; source.getOptionNames()) {
-                                                
-                                                // Skip options which shouldn't be shown
+                                            foreach (option; source.getOptionNames()) {
                                                 if (option == "appName") continue;
                                                 if (option == "address") continue;
 
                                                 if (option !in options[source]) options[source][option] = "";
                                                 uiImLabel(option);
                                                 string optionString = options[source][option].dup;
-                                                if (uiImInputText(option, avail.x/2, optionString)) {
+                                                if (uiImInputText(option, avail.x / 2, optionString)) {
                                                     options[source][option] = optionString.toStringz.fromStringz;
                                                 }
                                             }
@@ -314,15 +270,15 @@ public:
                                                     source.setOptions(options[source]);
                                                     source.stop();
                                                     source.start();
-                                                } catch(Exception ex) {
+                                                } catch (Exception ex) {
                                                     uiImDialog(__("Error"), ex.msg);
                                                 }
                                             }
 
-                                            // Expose the delete button to make sure users notice it.
                                             uiImSameLine(0, 40);
-                                            if (uiImButton(__("Delete")))
+                                            if (uiImButton(__("Delete"))) {
                                                 adaptorDelete(i);
+                                            }
                                         uiImUnindent();
                                     } else {
                                         adaptorMenu(i);
@@ -333,7 +289,7 @@ public:
                     uiImUnindent();
 
                     avail = uiImAvailableSpace();
-                    if (uiImButton(__(""), vec2(avail.x, 24))) {
+                    if (uiImButton(__("\ue145"), vec2(avail.x, 24))) {
                         editingZone.sources.length++;
                         refreshOptionsList();
                     }
@@ -342,10 +298,32 @@ public:
         }
         uiImEndChild();
 
-        igSetCursorPosX(max(0.0f, uiImAvailableSpace().x - 72.0f));
-        if (uiImButton(__("Apply"), vec2(64, 0))) {
-            applyChanges();
+        if (showApplyButton) {
+            igSetCursorPosX(max(0.0f, uiImAvailableSpace().x - 72.0f));
+            if (uiImButton(__("Apply"), vec2(64, 0))) {
+                applyChanges();
+            }
         }
+    }
+
+    override
+    void onBeginUpdate() {
+        ImVec2 wpos = ImVec2(
+            igGetMainViewport().Pos.x + (igGetMainViewport().Size.x / 2),
+            igGetMainViewport().Pos.y + (igGetMainViewport().Size.y / 2),
+        );
+
+        ImVec2 uiSize = ImVec2(800, 600);
+
+        igSetNextWindowPos(wpos, ImGuiCond.Appearing, ImVec2(0.5, 0.5));
+        igSetNextWindowSize(uiSize, ImGuiCond.Appearing);
+        igSetNextWindowSizeConstraints(uiSize, ImVec2(float.max, float.max));
+        super.onBeginUpdate();
+    }
+
+    override
+    void onUpdate() {
+        renderEditorSection(true);
     }
 
     this() {

--- a/source/nijiexpose/windows/spaceedit.d
+++ b/source/nijiexpose/windows/spaceedit.d
@@ -47,6 +47,14 @@ private:
         refreshOptionsList();
     }
 
+    void ensureEditingZone() {
+        if (editingZone !is null) return;
+        auto zones = insScene.space.getZones();
+        if (zones.length > 0) {
+            switchZone(zones[0]);
+        }
+    }
+
     void refreshOptionsList() {
         options.clear();
         if (editingZone is null) return;
@@ -303,6 +311,149 @@ public:
             if (uiImButton(__("Apply"), vec2(64, 0))) {
                 applyChanges();
             }
+        }
+    }
+
+    void renderEmbeddedSection() {
+        ensureEditingZone();
+
+        auto zones = insScene.space.getZones();
+        if (uiImBeginCategory(_("Zone").toStringz, UiImCategoryFlags.NoCollapse)) {
+            int zoneToDelete = -1;
+            foreach (idx, zone; zones) {
+                uiImPush(cast(int)idx);
+                    vec2 avail = uiImAvailableSpace();
+                    float rowWidth = max(0.0f, avail.x - 38.0f);
+                    bool selected = zone == editingZone;
+                    if (igSelectable(zone.name.toStringz, selected, ImGuiSelectableFlags.None, ImVec2(rowWidth, 0))) {
+                        switchZone(zone);
+                    }
+                    uiImSameLine();
+                    if (uiImButton(__("\ue872"), vec2(28, 0))) {
+                        zoneToDelete = cast(int)idx;
+                    }
+                uiImPop();
+            }
+
+            if (zoneToDelete >= 0) {
+                auto zonesNow = insScene.space.getZones();
+                bool deletedSelected = editingZone is zonesNow[zoneToDelete];
+                foreach (ref source; zonesNow[zoneToDelete].sources) {
+                    if (source) source.stop();
+                }
+                insScene.space.removeZoneAt(cast(size_t)zoneToDelete);
+                if (deletedSelected) {
+                    editingZone = null;
+                }
+                ensureEditingZone();
+                refreshOptionsList();
+                uiImEndCategory();
+                return;
+            }
+
+            string pendingZoneName = newZoneName.dup;
+            vec2 avail = uiImAvailableSpace();
+            if (uiImInputText("##EMBEDDED_ZONE_NAME", max(0.0f, avail.x - 38.0f), pendingZoneName)) {
+                try {
+                    newZoneName = pendingZoneName.toStringz.fromStringz;
+                } catch (std.utf.UTFException e) {}
+            }
+            uiImSameLine();
+            if (uiImButton(__("\ue145"), vec2(28, 0))) {
+                addZone();
+                ensureEditingZone();
+            }
+
+            if (editingZone is null) {
+                uiImLabel(_("No zone selected for editing..."));
+                uiImEndCategory();
+                return;
+            }
+            uiImEndCategory();
+        }
+
+        foreach (i; 0 .. editingZone.sources.length) {
+            if (i >= editingZone.sources.length) continue;
+
+            uiImPush(cast(int)i);
+                auto source = editingZone.sources[i];
+                const(char)* adaptorName = source is null ? __("Unset") : source.getAdaptorName().toStringz;
+
+                if (source is null) {
+                    if (uiImBeginCategory(adaptorName)) {
+                        adaptorMenu(i);
+                        ImVec2 headerStart;
+                        igGetItemRectMin(&headerStart);
+                        ImVec2 headerEnd;
+                        igGetItemRectMax(&headerEnd);
+                        float deleteX = headerEnd.x - 32.0f;
+                        float iconY = headerStart.y + 1.0f;
+                        igSetCursorScreenPos(ImVec2(deleteX, iconY));
+                        if (uiImButton(__("\ue872"), vec2(28, 0))) {
+                            adaptorDelete(i);
+                            uiImEndCategory();
+                            uiImPop();
+                            continue;
+                        }
+                        adaptorSelect(i, source, adaptorName);
+                    }
+                    uiImEndCategory();
+                } else {
+                    if (uiImBeginCategory(adaptorName)) {
+                        adaptorMenu(i);
+                        ImVec2 headerStart;
+                        igGetItemRectMin(&headerStart);
+                        ImVec2 headerEnd;
+                        igGetItemRectMax(&headerEnd);
+                        float iconY = headerStart.y + 1.0f;
+                        float deleteX = headerEnd.x - 32.0f;
+                        float saveX = deleteX - 32.0f;
+
+                        igSetCursorScreenPos(ImVec2(saveX, iconY));
+                        if (uiImButton(__("\ue161"), vec2(28, 0))) {
+                            try {
+                                source.setOptions(options[source]);
+                                source.stop();
+                                source.start();
+                            } catch (Exception ex) {
+                                uiImDialog(__("Error"), ex.msg);
+                            }
+                        }
+                        igSetCursorScreenPos(ImVec2(deleteX, iconY));
+                        if (uiImButton(__("\ue872"), vec2(28, 0))) {
+                            adaptorDelete(i);
+                            uiImEndCategory();
+                            uiImPop();
+                            continue;
+                        }
+
+                        vec2 avail = uiImAvailableSpace();
+                        adaptorSelect(i, source, adaptorName);
+                        igNewLine();
+
+                        foreach (option; source.getOptionNames()) {
+                            if (option == "appName") continue;
+                            if (option == "address") continue;
+
+                            if (option !in options[source]) options[source][option] = "";
+                            uiImLabel(option);
+                            string optionString = options[source][option].dup;
+                            if (uiImInputText(option, avail.x / 2, optionString)) {
+                                options[source][option] = optionString.toStringz.fromStringz;
+                            }
+                        }
+
+                        adaptorHint(source);
+                    }
+                    uiImEndCategory();
+                }
+            uiImPop();
+        }
+
+        vec2 avail = uiImAvailableSpace();
+        if (uiImButton(__("Add Source"), vec2(min(avail.x, 220.0f), 28))) {
+            editingZone.sources.length++;
+            refreshOptionsList();
         }
     }
 


### PR DESCRIPTION
## Summary

This PR reshapes the `nijiexpose` UI toward a `nijikan`-style overlay-driven layout, and reorganizes the Tracking / View / Parameters flows for more consistent presentation and interaction.

## Changes

- Adjusted the left navigation and overlay presentation to better match the `nijikan` UI structure
- Applied semi-transparent overlays with blur and shadow for a more consistent window/panel appearance
- Reworked `Tracking` and `View` into dedicated overlays
- Folded `Settings` / `Virtual Space` content into the `Tracking` / `View` overlays and simplified the navigation flow
- Moved `Apply` actions outside scrollable content areas to keep them fixed and explicit
- Refactored `Scene Settings`, `Rendering`, `Tracking Settings`, and `Virtual Space` into embedded overlay sections
- Updated `Parameters` category presentation, including grouping and background transparency behavior
- Rebuilt the `Virtual Space` zone management UI
  - existing zone list
  - add-new row
  - add / delete icon actions
- Moved `Save` / `Delete` actions for `Virtual Space` sources into the header area as icon buttons
- Extracted content-only rendering for `Scene Settings` so it can be displayed consistently inside the `View` overlay
- Revised tracking parameter / compound binding layout to better align the overall visual structure